### PR TITLE
Fix reportHbarComputersByEntity depth

### DIFF
--- a/inc/inventory.class.php
+++ b/inc/inventory.class.php
@@ -812,8 +812,7 @@ class PluginMreportingInventory Extends PluginMreportingBaseclass {
 
        $query = "SELECT `id`, `name`
                   FROM `glpi_entities`
-                  WHERE `entities_id` = '".$_SESSION['glpiactive_entity']."'
-                  AND {$this->where_entities_level}
+                  WHERE {$this->where_entities_level}
                   ORDER BY `name`";
        $result = $DB->query($query);
 


### PR DESCRIPTION
Currently reportHbarComputersByEntity is locked to the children of the current entity (```                  `entities_id` = '".$_SESSION['glpiactive_entity'].```. and thus any depth higher than 2 is ignored.