### PR TITLE
fix(helpdesk): fix reportSunburstTicketByCategories chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix the loss of profile rights when updating the plugin
+- Fix missing categories in `reportSunburstTicketByCategories` chart.
 
 ## [1.8.11] - 2025-02-05
 

--- a/inc/helpdesk.class.php
+++ b/inc/helpdesk.class.php
@@ -834,18 +834,21 @@ class PluginMreportingHelpdesk extends PluginMreportingBaseclass
         //get full parent list
         krsort($flat_datas);
         $itilcategory = new ITILCategory();
-        foreach ($flat_datas as $cat_id => $current_datas) {
-            if (!isset($flat_datas[$current_datas['parent']])) {
-                if (
-                    $current_datas['parent'] != 0
-                    && $itilcategory->getFromDB(intval($current_datas['parent']))
-                ) {
-                    $flat_datas[$current_datas['parent']] = [
-                        'id'     => $current_datas['parent'],
-                        'name'   => $itilcategory->fields['name'],
-                        'parent' => $itilcategory->fields['itilcategories_id'],
-                        'count'  => 0,
-                    ];
+        foreach ($flat_datas as $current_datas) {
+            $ancestors = getAncestorsOf(ITILCategory::getTable(), $current_datas['id']);
+            foreach ($ancestors as $ancestor) {
+                if (!isset($flat_datas[$ancestor])) {
+                    if (
+                        $ancestor != 0
+                        && $itilcategory->getFromDB(intval($ancestor))
+                    ) {
+                        $flat_datas[$ancestor] = [
+                            'id'     => $ancestor,
+                            'name'   => $itilcategory->fields['name'],
+                            'parent' => $itilcategory->fields['itilcategories_id'],
+                            'count'  => 0,
+                        ];
+                    }
                 }
             }
         }


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !42269
- The Distribution of tickets per category and child categories chart did not display subcategories if at least two ancestors were assigned to no tickets.

## Screenshots (if appropriate):

Before fix:
<img width="976" height="1063" alt="image" src="https://github.com/user-attachments/assets/bc41a2c0-4563-4a15-ac90-b5741174ba3c" />

After fix:
<img width="981" height="1148" alt="image" src="https://github.com/user-attachments/assets/947de4d5-b7e8-4d65-8501-ddf6de1ddd10" />
