### PR TITLE
fix(helpdesk): fix reportSunburstTicketByCategories chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix GLIP Stat injection
 - Fix missing icon
+- Fix missing categories in `reportSunburstTicketByCategories` chart.
 
 ## [1.9.3] - 2026-01-08
 

--- a/inc/helpdesk.class.php
+++ b/inc/helpdesk.class.php
@@ -850,15 +850,17 @@ class PluginMreportingHelpdesk extends PluginMreportingBaseclass
         //get full parent list
         krsort($flat_datas);
         $itilcategory = new ITILCategory();
-        foreach ($flat_datas as $cat_id => $current_datas) {
-            if (!isset($flat_datas[$current_datas['parent']]) && ($current_datas['parent'] != 0 && $itilcategory->getFromDB(intval($current_datas['parent'])))) {
-
-                $flat_datas[$current_datas['parent']] = [
-                    'id'     => $current_datas['parent'],
-                    'name'   => htmlspecialchars($itilcategory->fields['name']),
-                    'parent' => $itilcategory->fields['itilcategories_id'],
-                    'count'  => 0,
-                ];
+        foreach ($flat_datas as $current_datas) {
+            $ancestors = getAncestorsOf(ITILCategory::getTable(), $current_datas['id']);
+            foreach ($ancestors as $ancestor) {
+                if (!isset($flat_datas[$ancestor]) && $ancestor != 0 && $itilcategory->getFromDB(intval($ancestor))) {
+                    $flat_datas[$ancestor] = [
+                        'id'     => $ancestor,
+                        'name'   => htmlspecialchars($itilcategory->fields['name']),
+                        'parent' => $itilcategory->fields['itilcategories_id'],
+                        'count'  => 0,
+                    ];
+                }
             }
         }
 


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !42269
- The Distribution of tickets per category and child categories chart did not display subcategories if at least two ancestors were assigned to no tickets.
https://github.com/pluginsGLPI/mreporting/pull/351

## Screenshots (if appropriate):

Before fix:
<img width="1579" height="653" alt="image" src="https://github.com/user-attachments/assets/186cf53f-9c4e-46f0-9e32-1aaa68576e30" />

After fix:
<img width="1579" height="653" alt="image" src="https://github.com/user-attachments/assets/e702fa3d-2382-47f6-a2fb-11aea26f49d3" />
