### PR TITLE
Fix(dashboard): reject invalid reports_id when adding a widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix dashboard crash when adding a report without selecting one (invalid `reports_id` value)
+
 ## [1.9.5] - 2026-05-12
 
 ### Fixed

--- a/front/dashboard.form.php
+++ b/front/dashboard.form.php
@@ -44,9 +44,11 @@ if (isset($_POST['saveConfig'])) {
 
     Html::back();
 } elseif (isset($_POST['addReports'])) {
-    $dashboard = new PluginMreportingDashboard();
-    $post      = ['users_id' => $_SESSION['glpiID'], 'reports_id' => $_POST['report']];
-    $dashboard->add($post);
+    $report_id = (int) ($_POST['report'] ?? 0);
+    if ($report_id > 0) {
+        $dashboard = new PluginMreportingDashboard();
+        $dashboard->add(['users_id' => $_SESSION['glpiID'], 'reports_id' => $report_id]);
+    }
 
     Html::back();
 } else {

--- a/hook.php
+++ b/hook.php
@@ -238,6 +238,16 @@ function plugin_mreporting_install()
     $migration->addField('glpi_plugin_mreporting_preferences', 'selectors', 'text');
     $migration->migrationOneTable('glpi_plugin_mreporting_preferences');
 
+    // == Fix dashboard entries with invalid reports_id (e.g. -1 from empty dropdown selection)
+    $DB->delete('glpi_plugin_mreporting_dashboards', ['reports_id' => ['<=', 0]]);
+    $migration->changeField(
+        'glpi_plugin_mreporting_dashboards',
+        'reports_id',
+        'reports_id',
+        "int {$default_key_sign} NOT NULL",
+    );
+    $migration->migrationOneTable('glpi_plugin_mreporting_dashboards');
+
     // == Init available reports
     require_once __DIR__ . '/inc/baseclass.class.php';
     require_once __DIR__ . '/inc/common.class.php';


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !44193

Submitting the "add report" form without selecting a report posted `-1` (the empty dropdown sentinel value) into the `reports_id` column, which is defined `UNSIGNED NOT NULL` and rejects negative values. The form now validates the posted value before inserting. The migration purges any existing invalid rows and enforces the unsigned constraint on older installs.

## Screenshots (if appropriate):
