### PR TITLE
Fix - Ensure selected states is always an array in inventory selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASED]
+
+### Fixed
+
+- Fix - Ensure selected states is always an array in inventory selector
+
 ## [1.9.6] - 2026-05-22
 
 ### Fixed

--- a/inc/inventory.class.php
+++ b/inc/inventory.class.php
@@ -45,6 +45,9 @@ class PluginMreportingInventory extends PluginMreportingBaseclass
         $selected_states = [];
         if (isset($_SESSION['mreporting_values'][$field])) {
             $selected_states = $_SESSION['mreporting_values'][$field];
+            if (!is_array($selected_states)) {
+                $selected_states = [];
+            }
         } else {
             $selected_states = self::getDefaultState();
         }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !44484
- Here is a brief description of what this PR does

When a user submits a search with an empty state field in mreporting reports (e.g. "Computers by OS"), the session stores an empty string instead of an array for the states selector. This causes a fatal error when `count()` is called on it, requiring a session cache flush to recover.

Added an `is_array()` guard after reading the session value so it always falls back to an empty array, preventing the crash.