### PR TITLE
fix(export): resolve missing data tables in ODT export by using isset() instead of property_exists()

### DIFF
--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -1251,7 +1251,7 @@ class PluginMreportingCommon extends CommonDBTM
         /** @var array $LANG */
         global $LANG;
 
-        $config = ['PATH_TO_TMP' => GLPI_DOC_DIR . '/_tmp'];
+        $config = ['PATH_TO_TMP' => GLPI_TMP_DIR];
 
         $category        = '';
         $description     = '';
@@ -1310,7 +1310,7 @@ class PluginMreportingCommon extends CommonDBTM
             } else {
                 $singledatas->setVars('datas_title', mb_strtoupper(__s('data', 'mreporting')), false, 'utf-8');
                 foreach ($datas as $key => $value) {
-                    if (property_exists($singledatas, 'datas') && $singledatas->datas !== null) {
+                    if (isset($singledatas->datas) || $singledatas->datas !== null) {
                         $singledatas->datas->row($key, ENT_NOQUOTES, 'utf-8');
                         $singledatas->datas->value($value, ENT_NOQUOTES, 'utf-8');
                         $singledatas->datas->merge();


### PR DESCRIPTION
### Description
When exporting native reports to ODT format, the generated document includes the charts but the data tables are completely missing (the templates remain empty). 

### Cause
In `inc/common.class.php`, inside the `generateOdt()` method, the code relies on `property_exists()` to check if `$singledatas->datas` and `$multipledatas->datas` are available. 

However, the underlying Odf library uses PHP magic methods (`__get()`) to dynamically handle its segment properties. Because `property_exists()` evaluates only static/strict properties, it returns `false` on these magic properties. This skips the entire loop responsible for injecting the rows into the document.

### Solution
Replaced `property_exists()` with `isset()` in `inc/common.class.php` (lines 1294, 1300, and 1313) to properly trigger PHP's magic methods and allow the data table fields to be processed.

Thank you for reviewing this contribution!