### PR TITLE
Fix: enforce report access checks on view and export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Fix missing access and validation checks on several report and admin actions
+
 ## [1.10.0] - 2026-06-10
 
 ### Fixed

--- a/front/preference.form.php
+++ b/front/preference.form.php
@@ -37,6 +37,10 @@ if (!isset($_GET['id'])) {
 $pref = new PluginMreportingPreference();
 
 if (isset($_POST['update'])) {
+    if (!$pref->getFromDB($_POST['id']) || $pref->fields['users_id'] != Session::getLoginUserID()) {
+        Html::back();
+    }
+    $_POST['users_id'] = Session::getLoginUserID();
     $pref->update($_POST);
     Html::back();
 } else {

--- a/front/profile.form.php
+++ b/front/profile.form.php
@@ -28,7 +28,7 @@
  * -------------------------------------------------------------------------
  */
 
-Session::checkRight('profile', READ);
+Session::checkRight('profile', UPDATE);
 
 /** @var DBmysql $DB */
 global $DB;

--- a/hook.php
+++ b/hook.php
@@ -361,8 +361,8 @@ function plugin_mreporting_giveItem($type, $ID, $data, $num)
                                 }
                             }
                         }
-                        $out = "<a href='config.form.php?id=" . $data['id'] . "'>" .
-                        $data['raw']["ITEM_$num"] . '</a> (' . $title_func . ')';
+                        $out = "<a href='config.form.php?id=" . htmlspecialchars((string) $data['id'], ENT_QUOTES) . "'>" .
+                        htmlspecialchars($data['raw']["ITEM_$num"], ENT_QUOTES) . '</a> (' . $title_func . ')';
                     }
 
                     return $out;

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -612,6 +612,24 @@ class PluginMreportingCommon extends CommonDBTM
     }
 
     /**
+     * Reject the request unless the report is active and the current profile
+     * has read access to it (mirrors the check used to build the reports menu,
+     * but enforced here on the actual data-returning endpoints).
+     */
+    private static function checkReportAccess($f_name, $classname)
+    {
+        $config = new PluginMreportingConfig();
+        if (
+            !$config->getFromDBByFunctionAndClassname($f_name, $classname)
+            || !$config->fields['is_active']
+            || !isset($_SESSION['glpiactiveprofile']['id'])
+            || !PluginMreportingProfile::canViewReports($_SESSION['glpiactiveprofile']['id'], $config->fields['id'])
+        ) {
+            throw new NotFoundHttpException();
+        }
+    }
+
+    /**
      * show Graph : Show graph
      *
      * @params $options ($opt, export)
@@ -671,6 +689,7 @@ class PluginMreportingCommon extends CommonDBTM
         if (!is_a($classname, PluginMreportingBaseclass::class, true)) {
             return false;
         }
+        self::checkReportAccess($opt['f_name'], $classname);
         $obj = new $classname($config);
 
         $datas = $obj->{$opt['f_name']}($config);
@@ -1115,6 +1134,9 @@ class PluginMreportingCommon extends CommonDBTM
                     foreach ($report['functions'] as $func) {
                         foreach ($opt['check'] as $do => $to) {
                             if ($do == $func['function'] . $classname) {
+                                if (!$func['is_active'] || !$func['right']) {
+                                    continue;
+                                }
                                 //dynamic instanciation of class passed by 'short_classname' GET parameter
                                 $config   = PluginMreportingConfig::initConfigParams($func['function'], $classname);
                                 $class    = 'PluginMreporting' . $func['short_classname'];
@@ -1206,6 +1228,7 @@ class PluginMreportingCommon extends CommonDBTM
             if (!is_a($classname, PluginMreportingBaseclass::class, true)) {
                 return false;
             }
+            self::checkReportAccess($opt['f_name'], $classname);
             $obj       = new $classname($config);
 
             //dynamic call of method passed by 'f_name' GET parameter with previously instancied class

--- a/inc/dashboard.class.php
+++ b/inc/dashboard.class.php
@@ -271,6 +271,9 @@ class PluginMreportingDashboard extends CommonDBTM
     public static function removeReportFromDashboard($id)
     {
         $report = new PluginMreportingDashboard();
+        if (!$report->getFromDB($id) || $report->fields['users_id'] != Session::getLoginUserID()) {
+            return false;
+        }
 
         return $report->delete(['id' => $id]);
     }

--- a/inc/graphcsv.class.php
+++ b/inc/graphcsv.class.php
@@ -42,6 +42,17 @@ class PluginMreportingGraphcsv extends PluginMreportingGraph
         }
     }
 
+    /**
+     * Prefix a leading =, +, - or @ so spreadsheet software doesn't
+     * interpret the field as a formula.
+     */
+    private static function escapeCsvField($value)
+    {
+        $value = (string) $value;
+
+        return preg_match('/^[=+\-@]/', $value) ? "'" . $value : $value;
+    }
+
     public function showHbar($params, $dashboard = false, $width = false)
     {
         /** @var array $CFG_GLPI */
@@ -91,7 +102,7 @@ class PluginMreportingGraphcsv extends PluginMreportingGraph
         //titles
         $out = $title . ' - ' . $desc . "\r\n";
         foreach ($labels as $label) {
-            $out .= $label . $CFG_GLPI['csv_delimiter'];
+            $out .= self::escapeCsvField($label) . $CFG_GLPI['csv_delimiter'];
         }
         $out = substr($out, 0, -1) . "\r\n";
 
@@ -101,7 +112,7 @@ class PluginMreportingGraphcsv extends PluginMreportingGraph
         }
         $out = substr($out, 0, -1) . "\r\n";
 
-        echo htmlspecialchars($out);
+        echo $out;
     }
 
     public function showPie($params, $dashboard = false, $width = false)
@@ -158,7 +169,7 @@ class PluginMreportingGraphcsv extends PluginMreportingGraph
 
         foreach ($datas as $label2 => $cols) {
             //title
-            $out .= $label2 . "\r\n";
+            $out .= self::escapeCsvField($label2) . "\r\n";
 
             //subtitle
             $i = 0;
@@ -167,7 +178,7 @@ class PluginMreportingGraphcsv extends PluginMreportingGraph
                 if (isset($labels2[$i])) {
                     $label = str_replace(',', '-', $labels2[$i]);
                 }
-                $out .= $label . $CFG_GLPI['csv_delimiter'];
+                $out .= self::escapeCsvField($label) . $CFG_GLPI['csv_delimiter'];
                 $i++;
             }
             $out = substr($out, 0, -1) . "\r\n";
@@ -180,7 +191,7 @@ class PluginMreportingGraphcsv extends PluginMreportingGraph
         }
         $out = substr($out, 0, -1) . "\r\n";
 
-        echo htmlspecialchars($out);
+        echo $out;
     }
 
     public function showVstackbar($params, $dashboard = false, $width = false)

--- a/inc/helpdesk.class.php
+++ b/inc/helpdesk.class.php
@@ -996,7 +996,7 @@ class PluginMreportingHelpdesk extends PluginMreportingBaseclass
         $delay = PluginMreportingCommon::getCriteriaDate('glpi_tickets.date', $config['delay'], $config['randname']);
 
         $datas = [];
-        $limit = $_REQUEST['glpilist_limit'] ?? 20;
+        $limit = (int) ($_REQUEST['glpilist_limit'] ?? 20);
 
         $query = [
             "SELECT" => [
@@ -1034,7 +1034,7 @@ class PluginMreportingHelpdesk extends PluginMreportingBaseclass
             ],
             'GROUPBY' => [Location::getTable() . '.name'],
             'ORDER' => ['count DESC'],
-            'LIMIT' => '0, ' . $limit,
+            'LIMIT' => $limit,
         ];
         $query['WHERE']['AND'] = $delay;
 

--- a/inc/helpdeskplus.class.php
+++ b/inc/helpdeskplus.class.php
@@ -664,7 +664,7 @@ class PluginMreportingHelpdeskplus extends PluginMreportingBaseclass
 
         //Init delay value
         $delay = PluginMreportingCommon::getCriteriaDate('glpi_tickets.date', $config['delay'], $config['randname']);
-        $limit = $_SESSION['mreporting_values']['glpilist_limit'] ?? 20;
+        $limit = (int) ($_SESSION['mreporting_values']['glpilist_limit'] ?? 20);
 
         $query = [
             "SELECT" => [
@@ -718,7 +718,7 @@ class PluginMreportingHelpdeskplus extends PluginMreportingBaseclass
 
         //Init delay value
         $delay = PluginMreportingCommon::getCriteriaDate('glpi_tickets.date', $config['delay'], $config['randname']);
-        $limit = $_SESSION['mreporting_values']['glpilist_limit'] ?? 20;
+        $limit = (int) ($_SESSION['mreporting_values']['glpilist_limit'] ?? 20);
 
         $query = [
             "SELECT" => [
@@ -1009,7 +1009,7 @@ class PluginMreportingHelpdeskplus extends PluginMreportingBaseclass
 
         $category = isset($_POST['categories']) && $_POST['categories'] > 0 ? $_POST['categories'] : false;
 
-        $category_limit = $_POST['glpilist_limit'] ?? 10;
+        $category_limit = (int) ($_POST['glpilist_limit'] ?? 10);
 
         $_SESSION['glpilist_limit'] = $category_limit;
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -14,11 +14,14 @@
         <TaintedTextWithQuotes>
             <errorLevel type="suppress">
             <file name="inc/graph.class.php" />
+            <!-- CSV response, not HTML: formula-injection is mitigated in escapeCsvField() instead -->
+            <file name="inc/graphcsv.class.php" />
             </errorLevel>
         </TaintedTextWithQuotes>
         <TaintedHtml>
             <errorLevel type="suppress">
             <file name="inc/graph.class.php" />
+            <file name="inc/graphcsv.class.php" />
             </errorLevel>
         </TaintedHtml>
         <TaintedCallable errorLevel="suppress" />

--- a/setup.php
+++ b/setup.php
@@ -78,8 +78,10 @@ function plugin_init_mreporting()
     if (Plugin::isPluginActive('mreporting')) {
         // *Direct* access to rapport file (from e-mail) :
         if (isset($_GET['redirect']) && str_contains($_GET['redirect'], 'plugin_mreporting')) {
-            $filename = str_replace('plugin_mreporting_', '', $_GET['redirect']);
-            Html::redirect($CFG_GLPI['root_doc'] . '/files/_plugins/mreporting/notifications/' . $filename);
+            $filename = basename(str_replace('plugin_mreporting_', '', $_GET['redirect']));
+            if (preg_match('/^[\w\-.]+$/', $filename)) {
+                Html::redirect($CFG_GLPI['root_doc'] . '/files/_plugins/mreporting/notifications/' . $filename);
+            }
         }
 
         //Load additionnal language files in needed


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #N/A
- Viewing or exporting a report now correctly checks the per-profile access rights and the report's enabled state instead of ignoring them.
- The report rights page now requires the right level that matches the write actions it performs.
- Dashboard and preference actions now check that the entry belongs to the current user before changing it, and a list size taken from the request is now safely converted to a number.
- A rendered value is now properly escaped, a redirect file name is sanitized, and CSV exports no longer corrupt cell content while guarding against a leading formula character.

## Screenshots (if appropriate):
